### PR TITLE
Increase maximum AVI frame limit

### DIFF
--- a/CaptureCfg.cpp
+++ b/CaptureCfg.cpp
@@ -1,6 +1,7 @@
 // CaptureCfg.cpp : implementation file
 //
 
+#include <limits>
 #include "stdafx.h"
 #include "WinDV.h"
 #include "CaptureCfg.h"
@@ -42,7 +43,7 @@ void CCaptureCfg::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_EVERY_NTH, m_everyNth);
 	DDV_MinMaxUInt(pDX, m_everyNth, 1, 1000000);
 	DDX_Text(pDX, IDC_MAX_FRAMES, m_maxAVIFrames);
-	DDV_MinMaxUInt(pDX, m_maxAVIFrames, 10, 1000000);
+	DDV_MinMaxUInt(pDX, m_maxAVIFrames, 10, std::numeric_limits<UINT>::max());
 	DDX_Radio(pDX, IDC_TYPE_1, m_type12);
 	DDX_CBString(pDX, IDC_DTFORMAT, m_dtformat);
 	DDX_CBIndex(pDX, IDC_NDIGITS, m_ndigits);

--- a/CaptureCfg.cpp
+++ b/CaptureCfg.cpp
@@ -1,7 +1,7 @@
 // CaptureCfg.cpp : implementation file
 //
 
-#include <limits>
+#include <limits.h>
 #include "stdafx.h"
 #include "WinDV.h"
 #include "CaptureCfg.h"
@@ -43,7 +43,7 @@ void CCaptureCfg::DoDataExchange(CDataExchange* pDX)
 	DDX_Text(pDX, IDC_EVERY_NTH, m_everyNth);
 	DDV_MinMaxUInt(pDX, m_everyNth, 1, 1000000);
 	DDX_Text(pDX, IDC_MAX_FRAMES, m_maxAVIFrames);
-	DDV_MinMaxUInt(pDX, m_maxAVIFrames, 10, std::numeric_limits<UINT>::max());
+	DDV_MinMaxUInt(pDX, m_maxAVIFrames, 10, UINT_MAX);
 	DDX_Radio(pDX, IDC_TYPE_1, m_type12);
 	DDX_CBString(pDX, IDC_DTFORMAT, m_dtformat);
 	DDX_CBIndex(pDX, IDC_NDIGITS, m_ndigits);

--- a/DShow.h
+++ b/DShow.h
@@ -203,9 +203,9 @@ class CDV:public CStatic, CFrameHandler  {
 public:
 	enum {Idle, RecordPaused, Recording, CapturePaused, Capturing, Finished} m_state;
 	bool m_type2AVI;
-	int m_discontinuityTreshold;
-	int m_maxAVIFrames;
-	int m_everyNth;
+	UINT m_discontinuityTreshold;
+	UINT m_maxAVIFrames;
+	UINT m_everyNth;
 	bool m_recordPreview;
 	bool m_DVctrl;
 


### PR DESCRIPTION
There was previously an arbitrary limit of 100,000 frames on the length of captured video. The actual data type of this configurable limit is a 32-bit unsigned integer, so the maximum value has been raised to the maximum 32-bit unsigned integer value instead.

Some other things that were supposed to be 32-bit unsigned integers were for some reason signed integers instead, so their types have been fixed as well.

Resolves #2.